### PR TITLE
Update repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/myles/stdio-to-ws"
+    "url": "https://github.com/marimo-team/stdio-to-ws"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
e.g. So that `npm view stdio-to-ws` links to correct repo

```
stdio-to-ws@0.1.2 | Apache-2.0 | deps: 2 | versions: 1
Bridge stdio processes to WebSocket connections
https://github.com/myles/stdio-to-ws#readme

keywords: websocket, stdio, bridge, process

bin: stdio-to-ws

dist
.tarball: https://registry.npmjs.org/stdio-to-ws/-/stdio-to-ws-0.1.2.tgz
.shasum: 41585f917b8797338c6c8b94711aedf33dd02ed2
.integrity: sha512-y7cttlK/RUtUYDfkUbpjsP9EFMtgEBTJ0PfZleF5xn20iuo0bnsKngW9HC1RcuZeryHEKJAoctvoTRERRnQlcg==
.unpackedSize: 21.3 kB

dependencies:
minimist: ^1.2.8 ws: ^8.18.3      

maintainers:
- mscolnick <mscolnick@gmail.com>

dist-tags:
latest: 0.1.2  

published 6 days ago by mscolnick <mscolnick@gmail.com>
```