### PR TITLE
Add optional line framing for stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ npx stdio-to-ws [options] "stdio command"
 ## Options
 
 - `-p, --port <port>`: port to listen on (default: 3000)
-- `-f, --framing <mode>`: message framing (`raw` | `line`, default: `raw`)
+- `-f, --framing <mode>`: message framing (`raw` | `line`, default: `line`)
 - `-q, --quiet`: suppress logging output
 - `-h, --help`: show help
 
 ### Framing modes
 
-- `raw` (default): forwards stdout data chunks as-is and strips a leading `Content-Length` header if present
-- `line`: treats each stdout line as a message; useful for line-delimited protocols such as NDJSON (ACP uses NDJSON, so use `line` for ACP)
+- `line` (default): treats each stdout line as a message; useful for line-delimited protocols such as NDJSON (ACP uses NDJSON)
+- `raw`: forwards stdout data chunks as-is and strips a leading `Content-Length` header if present
 
 ## Example
 
 ```bash
-npx stdio-to-ws "npx @google/gemini-cli --experimental-acp" --port 3000 --framing line
+npx stdio-to-ws "npx @google/gemini-cli --experimental-acp" --port 3000
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,13 +5,25 @@ Redirect stdio to WebSocket.
 ## Usage
 
 ```bash
-npx stdio-to-ws "stdio command" --port 3000
+npx stdio-to-ws [options] "stdio command"
 ```
 
-Example:
+## Options
+
+- `-p, --port <port>`: port to listen on (default: 3000)
+- `-f, --framing <mode>`: message framing (`raw` | `line`, default: `raw`)
+- `-q, --quiet`: suppress logging output
+- `-h, --help`: show help
+
+### Framing modes
+
+- `raw` (default): forwards stdout data chunks as-is and strips a leading `Content-Length` header if present
+- `line`: treats each stdout line as a message; useful for line-delimited protocols such as NDJSON (ACP uses NDJSON, so use `line` for ACP)
+
+## Example
 
 ```bash
-npx stdio-to-ws "npx @google/gemini-cli --experimental-acp" --port 3000
+npx stdio-to-ws "npx @google/gemini-cli --experimental-acp" --port 3000 --framing line
 ```
 
 ## License

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { startWebSocketServer } from "./stdio-to-ws.js";
 
 const argv = minimist(process.argv.slice(2), {
   alias: { p: "port", h: "help", q: "quiet", f: "framing" },
-  default: { port: 3000, framing: "raw" },
+  default: { port: 3000, framing: "line" },
   boolean: ["quiet"],
   string: ["framing"],
 });
@@ -17,7 +17,7 @@ Usage: stdio-to-ws [options] <command>
 Options:
   -p, --port <port>    Port to listen on (default: 3000)
   -q, --quiet         Suppress logging output
-  -f, --framing <mode> Message framing: raw | line (default: raw)
+  -f, --framing <mode> Message framing: raw | line (default: line)
   -h, --help          Show this help message
 
 Example:

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,10 @@ import { parseArgsStringToArgv } from "string-argv";
 import { startWebSocketServer } from "./stdio-to-ws.js";
 
 const argv = minimist(process.argv.slice(2), {
-  alias: { p: "port", h: "help", q: "quiet" },
-  default: { port: 3000 },
+  alias: { p: "port", h: "help", q: "quiet", f: "framing" },
+  default: { port: 3000, framing: "raw" },
   boolean: ["quiet"],
+  string: ["framing"],
 });
 
 if (argv.help) {
@@ -16,6 +17,7 @@ Usage: stdio-to-ws [options] <command>
 Options:
   -p, --port <port>    Port to listen on (default: 3000)
   -q, --quiet         Suppress logging output
+  -f, --framing <mode> Message framing: raw | line (default: raw)
   -h, --help          Show this help message
 
 Example:
@@ -32,8 +34,15 @@ if (!cmd) {
   process.exit(1);
 }
 
+const framing = argv.framing;
+if (framing !== "raw" && framing !== "line") {
+  console.error(`Invalid framing mode: ${framing}`);
+  process.exit(1);
+}
+
 void startWebSocketServer({
   command: parseArgsStringToArgv(cmd),
   port: argv.port,
+  framing,
   quiet: argv.quiet,
 });

--- a/src/stdio-to-ws.ts
+++ b/src/stdio-to-ws.ts
@@ -1,9 +1,12 @@
 import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
 import { inspect } from "node:util";
 import type { WebSocket } from "ws";
 import { WebSocketServer } from "ws";
 
 let isQuiet = false;
+
+export type FramingMode = "raw" | "line";
 
 function logError(...args: unknown[]): void {
   if (!isQuiet) console.error("[stdio-to-ws]", ...args);
@@ -25,8 +28,44 @@ function prettyPrintMessage(
   }
 }
 
-function handleWebSocketConnection(command: string[], webSocket: WebSocket): void {
+function handleWebSocketConnection(
+  command: string[],
+  webSocket: WebSocket,
+  framing: FramingMode,
+): void {
   const child = spawn(command[0]!, command.slice(1));
+
+  const closeStdout = (() => {
+    if (framing === "line") {
+      child.stdout.setEncoding("utf8");
+      const stdoutLines = createInterface({
+        input: child.stdout,
+        crlfDelay: Infinity,
+      });
+      stdoutLines.on("line", (line) => {
+        try {
+          if (line.length === 0) return;
+          prettyPrintMessage("[Server → Client]", line);
+          webSocket.send(line);
+        } catch (error) {
+          logError("Failed to send data to WebSocket:", error);
+        }
+      });
+      return () => stdoutLines.close();
+    }
+
+    child.stdout.on("data", (data) => {
+      try {
+        const message = data.toString();
+        const content = message.replace(/^Content-Length: \d+\r?\n\r?\n/, "");
+        prettyPrintMessage("[Server → Client]", content);
+        webSocket.send(content);
+      } catch (error) {
+        logError("Failed to send data to WebSocket:", error);
+      }
+    });
+    return () => {};
+  })();
 
   child.on("error", (error) => {
     logError("Child process error:", error);
@@ -41,9 +80,15 @@ function handleWebSocketConnection(command: string[], webSocket: WebSocket): voi
   webSocket.on("message", (data) => {
     try {
       const message = data.toString();
-      const content = message.replace(/^Content-Length: \d+\r?\n\r?\n/, "");
-      prettyPrintMessage("[Client → Server]", content);
-      child.stdin.write(content);
+      if (framing === "line") {
+        prettyPrintMessage("[Client → Server]", message);
+        const line = message.endsWith("\n") || message.endsWith("\r\n") ? message : `${message}\n`;
+        child.stdin.write(line);
+      } else {
+        const content = message.replace(/^Content-Length: \d+\r?\n\r?\n/, "");
+        prettyPrintMessage("[Client → Server]", content);
+        child.stdin.write(content);
+      }
     } catch (error) {
       logError("Failed to write to child stdin:", error);
     }
@@ -51,17 +96,7 @@ function handleWebSocketConnection(command: string[], webSocket: WebSocket): voi
 
   webSocket.on("close", () => {
     child.kill();
-  });
-
-  child.stdout.on("data", (data) => {
-    try {
-      const message = data.toString();
-      const content = message.replace(/^Content-Length: \d+\r?\n\r?\n/, "");
-      prettyPrintMessage("[Server → Client]", content);
-      webSocket.send(content);
-    } catch (error) {
-      logError("Failed to send data to WebSocket:", error);
-    }
+    closeStdout();
   });
 
   child.stderr.on("data", (data) => {
@@ -73,9 +108,10 @@ export function startWebSocketServer(opts: {
   port: number;
   command: string[];
   corsOrigin?: string | string[] | boolean;
+  framing?: FramingMode;
   quiet?: boolean;
 }): void {
-  const { port, command, corsOrigin, quiet = false } = opts;
+  const { port, command, corsOrigin, framing = "raw", quiet = false } = opts;
   isQuiet = quiet;
 
   const wss = new WebSocketServer({
@@ -96,7 +132,7 @@ export function startWebSocketServer(opts: {
 
   wss.on("connection", (webSocket) => {
     log("New WebSocket connection");
-    handleWebSocketConnection(command, webSocket);
+    handleWebSocketConnection(command, webSocket, framing);
   });
 
   log(`WebSocket server listening on port ${port}`);

--- a/src/stdio-to-ws.ts
+++ b/src/stdio-to-ws.ts
@@ -111,7 +111,7 @@ export function startWebSocketServer(opts: {
   framing?: FramingMode;
   quiet?: boolean;
 }): void {
-  const { port, command, corsOrigin, framing = "raw", quiet = false } = opts;
+  const { port, command, corsOrigin, framing = "line", quiet = false } = opts;
   isQuiet = quiet;
 
   const wss = new WebSocketServer({


### PR DESCRIPTION
Related: #4 

This PR adds an opt-in `--framing=line` mode.
- Default behavior is unchanged (`--framing=raw`).
- In `line` mode, stdout is buffered until newline and forwarded as one WS message.

This prevents partial JSON fragments from being forwarded when stdout chunks split large messages.
