### PR TITLE
chore(ci): remove redundant npm@latest upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
-      - name: ⎔ Upgrade npm for OIDC support
-        run: pnpm install -g npm@latest
 
       - name: 📥 Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
node-24 ships with npm 11+ which already supports OIDC trusted publishing, so the `npm install -g npm@latest` step is redundant. Removing it also drops one global install in the same job as `id-token: write`.