### PR TITLE
chore(ci): split release.yml into build/publish/release-notes jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 permissions:
-  id-token: write  # Required for OIDC
-  contents: write
+  contents: read
 
 on:
   push:
@@ -10,7 +9,7 @@ on:
       - 'v*'
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -24,7 +23,6 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
 
@@ -64,12 +62,52 @@ jobs:
 
           echo "✅ Build artifacts validation passed"
 
+      - name: 📤 Upload package artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: package
+          path: |
+            dist/
+            package.json
+            README.md
+            LICENSE
+          retention-days: 1
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: 📥 Download package artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: package
+
       - name: 📦 Publish to NPM
-        run: npm publish
+        run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: "" # Clear placeholder set by setup-node to enable OIDC
+
+  release-notes:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: 📝 Update Changelog
         run: npx changelogithub
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: ⎔ Setup Node.js
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+            - name: ⎔ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
@@ -93,7 +96,7 @@ jobs:
           name: package
 
       - name: 📦 Publish to NPM
-        run: npm publish --ignore-scripts
+        run: pnpm publish --no-git-checks --ignore-scripts
         env:
           NODE_AUTH_TOKEN: "" # Clear placeholder set by setup-node to enable OIDC
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
 
       - name: 📥 Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --ignore-scripts --frozen-lockfile
 
       - name: 🔍 Type Check
         run: pnpm run typecheck
@@ -116,6 +116,6 @@ jobs:
           node-version: 24
 
       - name: 📝 Update Changelog
-        run: npx changelogithub
+        run: npx changelogithub@14.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
       - name: 📝 Update Changelog
         run: npx changelogithub
         env:


### PR DESCRIPTION
Splits the single release job into 3 jobs so the `id-token: write` scope is held only by a publish job that runs `npm publish` exclusively (no install/test/build/exec).

- **build** (no `id-token`): install, typecheck, test, build, validate, upload `dist/` + package metadata as artifact.
- **publish** (`id-token: write`): download artifact, `npm publish --ignore-scripts`.
- **release-notes** (`contents: write`, no `id-token`): `npx changelogithub`.

Mirrors marimo-team/codemirror-ai#111. No `notify` job since this repo's release workflow doesn't currently send a Slack notification.

Resolves the supply-chain audit `oidc-publish-fused` finding. Motivated by the TanStack npm supply-chain compromise (May 2026).