### PR TITLE
feat: send WebSocket ping frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ npx stdio-to-ws [options] "stdio command"
 
 - `-p, --port <port>`: port to listen on (default: 3000)
 - `-f, --framing <mode>`: message framing (`raw` | `line`, default: `line`)
+- `--ping <ms>`: Send WebSocket ping frames every `<ms>` milliseconds (default: 0, disabled)
 - `-q, --quiet`: suppress logging output
 - `-h, --help`: show help
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { startWebSocketServer } from "./stdio-to-ws.js";
 
 const argv = minimist(process.argv.slice(2), {
   alias: { p: "port", h: "help", q: "quiet", f: "framing" },
-  default: { port: 3000, framing: "line" },
+  default: { port: 3000, framing: "line", ping: 0 },
   boolean: ["quiet"],
   string: ["framing"],
 });
@@ -18,6 +18,7 @@ Options:
   -p, --port <port>    Port to listen on (default: 3000)
   -q, --quiet         Suppress logging output
   -f, --framing <mode> Message framing: raw | line (default: line)
+      --ping <ms>     Send WebSocket ping frames every <ms> milliseconds (default: 0, disabled)
   -h, --help          Show this help message
 
 Example:
@@ -44,5 +45,6 @@ void startWebSocketServer({
   command: parseArgsStringToArgv(cmd),
   port: argv.port,
   framing,
+  ping: argv.ping,
   quiet: argv.quiet,
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,10 +41,16 @@ if (framing !== "raw" && framing !== "line") {
   process.exit(1);
 }
 
+const ping = argv.ping;
+if (typeof ping !== "number" || ping < 0) {
+  console.error(`Invalid ping interval: ${ping}`);
+  process.exit(1);
+}
+
 void startWebSocketServer({
   command: parseArgsStringToArgv(cmd),
   port: argv.port,
   framing,
-  ping: argv.ping,
+  ping,
   quiet: argv.quiet,
 });

--- a/src/stdio-to-ws.ts
+++ b/src/stdio-to-ws.ts
@@ -32,6 +32,7 @@ function handleWebSocketConnection(
   command: string[],
   webSocket: WebSocket,
   framing: FramingMode,
+  ping: number,
 ): void {
   const child = spawn(command[0]!, command.slice(1));
 
@@ -94,7 +95,16 @@ function handleWebSocketConnection(
     }
   });
 
+  let interval: NodeJS.Timeout | null = null;
+  if (ping) {
+    interval = setInterval(() => webSocket.ping(), ping);
+  }
+
   webSocket.on("close", () => {
+    if (interval) {
+      clearInterval(interval);
+    }
+
     child.kill();
     closeStdout();
   });
@@ -109,9 +119,10 @@ export function startWebSocketServer(opts: {
   command: string[];
   corsOrigin?: string | string[] | boolean;
   framing?: FramingMode;
+  ping?: number;
   quiet?: boolean;
 }): void {
-  const { port, command, corsOrigin, framing = "line", quiet = false } = opts;
+  const { port, command, corsOrigin, framing = "line", ping = 0, quiet = false } = opts;
   isQuiet = quiet;
 
   const wss = new WebSocketServer({
@@ -132,7 +143,7 @@ export function startWebSocketServer(opts: {
 
   wss.on("connection", (webSocket) => {
     log("New WebSocket connection");
-    handleWebSocketConnection(command, webSocket, framing);
+    handleWebSocketConnection(command, webSocket, framing, ping);
   });
 
   log(`WebSocket server listening on port ${port}`);


### PR DESCRIPTION
Introduce a `--ping <ms>` option, adds support for sending periodic WebSocket ping frames to clients.