### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# stdio-to-ws
+
+CLI that bridges a stdio process to WebSocket connections (line/NDJSON or raw framing; used for ACP). Published to npm as `stdio-to-ws` (`npx stdio-to-ws`).
+
+## Development
+
+```bash
+pnpm install
+pnpm lint        # biome check --write (autofix.ci runs this on PRs)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # tsc -> dist/
+```
+
+- No test suite yet (`pnpm test` is a placeholder that just echoes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
This adds an `AGENTS.md` as the canonical agent-context doc, with `CLAUDE.md` as a symlink to it (`ln -s AGENTS.md CLAUDE.md`) so both Claude and other coding agents read the same file. Part of the marimo-team engineering-excellence initiative to standardize agent docs across repos. The content is deliberately minimal — a one-line overview plus verified development commands — because these files load into every agent context, so fewer tokens is better.